### PR TITLE
SVD: Fix SPIMSS block base address

### DIFF
--- a/max32660.svd
+++ b/max32660.svd
@@ -8427,7 +8427,7 @@
    <name>SPIMSS</name>
    <description>Serial Peripheral Interface.</description>
    <prependToName>SPIMSS0_</prependToName>
-   <baseAddress>0x40018000</baseAddress>
+   <baseAddress>0x40019000</baseAddress>
    <addressBlock>
     <offset>0x00</offset>
     <size>0x1000</size>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,7 +571,7 @@ pub struct SPIMSS {
 unsafe impl Send for SPIMSS {}
 impl SPIMSS {
     #[doc = r"Pointer to the register block"]
-    pub const PTR: *const spimss::RegisterBlock = 0x4001_8000 as *const _;
+    pub const PTR: *const spimss::RegisterBlock = 0x4001_9000 as *const _;
     #[doc = r"Return the pointer to the register block"]
     #[inline(always)]
     pub const fn ptr() -> *const spimss::RegisterBlock {


### PR DESCRIPTION
The SVD file currently puts the SPIMSS block at base offset 0x40018000. This is not correct for the MAX32660, where it is actually at 0x40019000. This can be checked from the datasheet (as unreliable as it normally is, it is telling the truth in this case) as well as the MaximSDK. I've also confirmed that 0x40019000 works on a physical chip.